### PR TITLE
Revert "feat(container): update registry-1.docker.io/cloudpirates/redis ( 0.11.2 → 0.12.0 )"

### DIFF
--- a/kubernetes/flux/repositories/oci/cloudpirates-redis.yaml
+++ b/kubernetes/flux/repositories/oci/cloudpirates-redis.yaml
@@ -11,5 +11,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.12.0
+    tag: 0.11.2
   url: oci://registry-1.docker.io/cloudpirates/redis


### PR DESCRIPTION
Reverts vember31/home-ops#3014

Due to issue: https://github.com/CloudPirates-io/helm-charts/issues/510