### PR TITLE
feat(plex): switch NFS volumes to PV/PVC with CSI driver

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -202,59 +202,59 @@ spec:
 
       tv:
         enabled: true
-        type: nfs
-        server: ${OMV_IP}
-        path: /export/media/tv
+        type: persistentVolumeClaim
+        existingClaim: nfs-omv-media
         globalMounts:
           - path: /media/tv
+            subPath: tv
             readOnly: true
 
       movies:
         enabled: true
-        type: nfs
-        server: ${OMV_IP}
-        path: /export/media/movies
+        type: persistentVolumeClaim
+        existingClaim: nfs-omv-media
         globalMounts:
           - path: /media/movies
+            subPath: movies
             readOnly: true
 
       # live tv recordings
       recordings:
         enabled: true
-        type: nfs
-        server: ${OMV_IP}
-        path: /export/media/recordings
+        type: persistentVolumeClaim
+        existingClaim: nfs-omv-media
         globalMounts:
           - path: /media/recordings
+            subPath: recordings
             readOnly: false
 
       # old hard drive in old server
       movies2:
         enabled: true
-        type: nfs
-        server: ${OMV2_IP}
-        path: /export/movies
+        type: persistentVolumeClaim
+        existingClaim: nfs-omv2
         globalMounts:
           - path: /media2/movies
+            subPath: movies
             readOnly: true
 
       # old hard drive in old server
       tv2:
         enabled: true
-        type: nfs
-        server: ${OMV2_IP}
-        path: /export/tv
+        type: persistentVolumeClaim
+        existingClaim: nfs-omv2
         globalMounts:
           - path: /media2/tv
+            subPath: tv
             readOnly: true
 
       # vids and stuff
       videos:
         enabled: true
-        type: nfs
-        server: ${OMV_IP}
-        path: /export/media/videos
+        type: persistentVolumeClaim
+        existingClaim: nfs-omv-media
         globalMounts:
           - path: /media/videos
+            subPath: videos
             readOnly: false
 


### PR DESCRIPTION
## Summary
- Switches Plex from inline NFS volume definitions to `existingClaim` PVC references
- NFS PVs are already migrated to the `nfs.csi.k8s.io` CSI driver on main
- Uses `subPath` mounts for each media directory (tv, movies, recordings, videos) against the shared PVCs

## Test plan
- [ ] Merge when ready to migrate Plex to PVC-based NFS mounts
- [ ] Verify Plex can access all media paths after merge (`/media/tv`, `/media/movies`, `/media/recordings`, `/media/videos`, `/media2/tv`, `/media2/movies`)
- [ ] Confirm liveness probe passes (checks all mount paths)